### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ First of all you have to upload animation submodule with `git submodule update -
 Or you can add gradle dependency with command :<br>
 ```groovy
 	dependencies {
-	    compile 'com.github.yalantis:Side-Menu.Android:1.0.1'
+	    implementation 'com.github.yalantis:Side-Menu.Android:1.0.1'
 	}
 ``` 
 .<br>
@@ -36,7 +36,7 @@ and command:<br>
 	    }
 	}
 	dependencies {
-	    compile 'com.github.ozodrukh:CircularReveal:(latest-release)@aar'
+	    implementation 'com.github.ozodrukh:CircularReveal:(latest-release)@aar'
 	}
 
 ```


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.